### PR TITLE
fix(creator-page): static page HTML cleanup

### DIFF
--- a/api-config.js
+++ b/api-config.js
@@ -1,0 +1,3 @@
+/** Backend API (Fly). Update here when the deploy URL changes. */
+export const API_BASE = 'https://error-affirmations-api.fly.dev';
+export const GITHUB_OAUTH_LOGIN_URL = `${API_BASE}/api/v1/github/login`;

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -1,4 +1,5 @@
 // import services and utilities
+import { GITHUB_OAUTH_LOGIN_URL } from '../api-config.js';
 import { getUser, signInUser, signUpUser } from '../fetch-utils.js';
 
 // If on this /auth page but we have a user, it means
@@ -17,6 +18,7 @@ const authButton = document.getElementById('auth-button');
 const changeType = document.getElementById('create-account');
 const errorDisplay = authForm.querySelector('.error');
 const ghButton = document.getElementById('github-button');
+ghButton.href = GITHUB_OAUTH_LOGIN_URL;
 const authTitle1 = document.getElementById('auth-title1');
 const authTitle2 = document.getElementById('auth-title2');
 

--- a/auth/index.html
+++ b/auth/index.html
@@ -47,7 +47,7 @@
                 <h3 class="auth-title" id="auth-title1">Using github...</h3>
                 <a
                     id="github-button"
-                    href="https://error-affirmations.herokuapp.com/api/v1/github/login"
+                    href="https://error-affirmations-api.fly.dev/api/v1/github/login"
                     ><img id="github-img" src="/assets/github-logo.png"
                 /></a>
                 <h3 class="auth-title" id="auth-title2">Or email and password!</h3>

--- a/creator-page/index.html
+++ b/creator-page/index.html
@@ -7,9 +7,6 @@
         <title>About the Creators</title>
         <link rel="icon" type="image/x-icon" href="/assets/affirmation-logo.png" />
 
-        <!-- js -->
-        <script type="module" src="app.js"></script>
-
         <!-- fonts -->
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -28,9 +25,9 @@
     </head>
     <body>
         <header class="page-header">
-            <img class="logo" src="../assets/affirmation-logo-black.png" />
+            <img class="logo" src="../assets/affirmation-logo-black.png" alt="" />
             <p class="title">Error Affirmations</p>
-            <img class="logo" src="../assets/affirmation-logo-black.png" />
+            <img class="logo" src="../assets/affirmation-logo-black.png" alt="" />
         </header>
         <nav>
             <div id="menu">
@@ -53,34 +50,34 @@
                         <h2 class="card-name">Karl Wernsman</h2>
                         <p class="creator-title">Full-Stack Software Developer</p>
                         <div class="link-div">
-                            <a href="https://www.linkedin.com/in/karl-wernsman/"
-                                ><img src="/assets/linkedin-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href="https://github.com/karlwernsman"
-                                ><img src="/assets/github-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href="mailto: wernsmank@gmail.com"
-                                ><img src="/assets/email-logo.png" class="link-icon"></img
-                            ></a>
+                            <a href="https://www.linkedin.com/in/karl-wernsman/">
+                                <img src="/assets/linkedin-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="https://github.com/karlwernsman">
+                                <img src="/assets/github-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="mailto: wernsmank@gmail.com">
+                                <img src="/assets/email-logo.png" class="link-icon" alt="" />
+                            </a>
                         </div>
                     </div>
                 </div>
 
                 <div class="card nes-input">
-                    <img src="/assets/rio.png" alt="Rio" style=/>
+                    <img src="/assets/rio.png" alt="Rio" />
                     <div class="container">
                         <h2 class="card-name">Rio Edwards</h2>
                         <p class="creator-title">Full-Stack Software Developer</p>
                         <div class="link-div">
-                            <a href="https://www.linkedin.com/in/rio-edwards/"
-                                ><img src="/assets/linkedin-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href="https://github.com/rioredwards"
-                                ><img src="/assets/github-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href="mailto: rioedwards@gmail.com"
-                                ><img src="/assets/email-logo.png" class="link-icon"></img
-                            ></a>
+                            <a href="https://www.linkedin.com/in/rio-edwards/">
+                                <img src="/assets/linkedin-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="https://github.com/rioredwards">
+                                <img src="/assets/github-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="mailto: rioedwards@gmail.com">
+                                <img src="/assets/email-logo.png" class="link-icon" alt="" />
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -91,15 +88,15 @@
                         <h2 class="card-name">Kevin Nail</h2>
                         <p class="creator-title">Full-Stack Software Developer</p>
                         <div class="link-div">
-                            <a href="https://www.linkedin.com/in/kevinnail/"
-                                ><img src="/assets/linkedin-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href=" https://github.com/kevinnail"
-                                ><img src="/assets/github-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href="mailto: fumalicious@gmail.com"
-                                ><img src="/assets/email-logo.png" class="link-icon"></img
-                            ></a>
+                            <a href="https://www.linkedin.com/in/kevinnail/">
+                                <img src="/assets/linkedin-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="https://github.com/kevinnail">
+                                <img src="/assets/github-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="mailto: fumalicious@gmail.com">
+                                <img src="/assets/email-logo.png" class="link-icon" alt="" />
+                            </a>
                         </div>
                     </div>
                 </div>
@@ -110,15 +107,15 @@
                         <h2 class="card-name">Zach Sultan</h2>
                         <p class="creator-title">Full-Stack Software Developer</p>
                         <div class="link-div">
-                            <a href="https://www.linkedin.com/in/zachary-sultan/"
-                                ><img src="/assets/linkedin-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href="https://github.com/Zacharyjsultan"
-                                ><img src="/assets/github-logo.png" class="link-icon"></img
-                            ></a>
-                            <a href="mailto: zacharyjsultan@gmail.com"
-                                ><img src="/assets/email-logo.png" class="link-icon"></img
-                            ></a>
+                            <a href="https://www.linkedin.com/in/zachary-sultan/">
+                                <img src="/assets/linkedin-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="https://github.com/Zacharyjsultan">
+                                <img src="/assets/github-logo.png" class="link-icon" alt="" />
+                            </a>
+                            <a href="mailto: zacharyjsultan@gmail.com">
+                                <img src="/assets/email-logo.png" class="link-icon" alt="" />
+                            </a>
                         </div>
                     </div>
                 </div>

--- a/fetch-utils.js
+++ b/fetch-utils.js
@@ -1,8 +1,8 @@
-const BASE_URL = 'https://error-affirmations.herokuapp.com';
+import { API_BASE } from './api-config.js';
 
 /* Auth related functions */
 export async function getUser() {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/me`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/me`, {
         method: 'GET',
         headers: {
             Accept: 'application/json',
@@ -17,7 +17,7 @@ export async function getUser() {
 }
 
 export async function signUpUser(email, password) {
-    const resp = await fetch(`${BASE_URL}/api/v1/users`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',
@@ -36,7 +36,7 @@ export async function signUpUser(email, password) {
     return data;
 }
 export async function signInUser(email, password) {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/sessions`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',
@@ -54,7 +54,7 @@ export async function signInUser(email, password) {
     return data;
 }
 export async function signOutUser() {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/sessions`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
         method: 'DELETE',
         credentials: 'include',
     });
@@ -65,7 +65,7 @@ export async function signOutUser() {
 
 /* Data functions */
 export async function fetchAffirmations() {
-    const res = await fetch(`${BASE_URL}/api/v1/affirmations`, {
+    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
         method: 'GET',
         headers: {
             Accept: 'application/json',
@@ -83,7 +83,7 @@ export async function fetchAffirmations() {
 }
 
 export async function createAffirmation(text, category_id) {
-    const res = await fetch(`${BASE_URL}/api/v1/affirmations`, {
+    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',


### PR DESCRIPTION
Removes the missing `app.js` module script from the static creators page, fixes the invalid `style=\/>` on Rio's image, and normalizes `<img>` usage (void elements, `alt` for decorative images, correct Kevin GitHub `href`).

- ESLint@8: `npx eslint@8 . --ext .js` (pass)

Made with [Cursor](https://cursor.com)