### PR TITLE
fix: affirmation form category_id contract and resilient fetch errors

### DIFF
--- a/api-config.js
+++ b/api-config.js
@@ -1,0 +1,3 @@
+/** Backend API (Fly). Update here when the deploy URL changes. */
+export const API_BASE = 'https://error-affirmations-api.fly.dev';
+export const GITHUB_OAUTH_LOGIN_URL = `${API_BASE}/api/v1/github/login`;

--- a/app.js
+++ b/app.js
@@ -3,6 +3,14 @@ import './auth/user.js';
 
 import { createAffirmation, fetchAffirmations } from './fetch-utils.js';
 
+/** Display labels for `category_id` from GET /api/v1/categories (values on `<select name="category">`). */
+const CATEGORY_LABELS = {
+    1: 'Daily',
+    2: 'Error',
+    3: 'TDD',
+    4: 'Will to go on',
+};
+
 /* Get DOM Elements */
 const addAffirmationForm = document.getElementById('add-affirmation-form');
 const submitButton = document.getElementById('submit-button');
@@ -16,45 +24,59 @@ let affirmations = [];
 /* Events */
 window.addEventListener('load', async () => {
     affirmations = [];
-    affirmations = await fetchAffirmations();
+    const result = await fetchAffirmations();
+    if (!result.ok) {
+        error = { message: result.message };
+        displayError();
+        return;
+    }
+    error = null;
+    affirmations = Array.isArray(result.data) ? result.data : [];
+    displayError();
     displayAffirmations();
 });
 
 addAffirmationForm.addEventListener('submit', async (e) => {
     e.preventDefault();
     submitButton.disabled = true;
-
-    const formData = new FormData(addAffirmationForm);
-    const text = formData.get('text');
-    const category = formData.get('category');
-
-    const response = await createAffirmation(text, category);
-    affirmations.unshift(response);
-    await displayAffirmations();
-
-    addAffirmationForm.reset();
-    submitButton.disabled = false;
+    try {
+        error = null;
+        displayError();
+        const formData = new FormData(addAffirmationForm);
+        const text = formData.get('text');
+        const category_id = formData.get('category');
+        const result = await createAffirmation(text, category_id);
+        if (!result.ok) {
+            error = { message: result.message };
+            displayError();
+            return;
+        }
+        affirmations.unshift(result.data);
+        displayAffirmations();
+        addAffirmationForm.reset();
+    } finally {
+        submitButton.disabled = false;
+    }
 });
 /* Display Functions */
-async function displayAffirmations() {
+function displayAffirmations() {
     affirmationList.innerHTML = '';
-    for (let affirmation of affirmations) {
+    for (const affirmation of affirmations) {
+        if (!affirmation) {
+            continue;
+        }
         const li = document.createElement('li');
         const h3 = document.createElement('p');
         const p = document.createElement('p');
         h3.textContent = affirmation.text;
-        p.textContent = affirmation.category;
+        const id = affirmation.category_id;
+        p.textContent =
+            CATEGORY_LABELS[id] || affirmation.category || id || '—';
         li.append(h3, p);
         affirmationList.append(li);
     }
 }
 
 function displayError() {
-    if (error) {
-        // eslint-disable-next-line no-console
-        console.log(error);
-        errorDisplay.textContent = error.message;
-    } else {
-        errorDisplay.textContent = '';
-    }
+    errorDisplay.textContent = error ? error.message : '';
 }

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -1,4 +1,5 @@
 // import services and utilities
+import { GITHUB_OAUTH_LOGIN_URL } from '../api-config.js';
 import { getUser, signInUser, signUpUser } from '../fetch-utils.js';
 
 // If on this /auth page but we have a user, it means
@@ -17,6 +18,7 @@ const authButton = document.getElementById('auth-button');
 const changeType = document.getElementById('create-account');
 const errorDisplay = authForm.querySelector('.error');
 const ghButton = document.getElementById('github-button');
+ghButton.href = GITHUB_OAUTH_LOGIN_URL;
 const authTitle1 = document.getElementById('auth-title1');
 const authTitle2 = document.getElementById('auth-title2');
 

--- a/auth/index.html
+++ b/auth/index.html
@@ -47,7 +47,7 @@
                 <h3 class="auth-title" id="auth-title1">Using github...</h3>
                 <a
                     id="github-button"
-                    href="https://error-affirmations.herokuapp.com/api/v1/github/login"
+                    href="https://error-affirmations-api.fly.dev/api/v1/github/login"
                     ><img id="github-img" src="/assets/github-logo.png"
                 /></a>
                 <h3 class="auth-title" id="auth-title2">Or email and password!</h3>

--- a/fetch-utils.js
+++ b/fetch-utils.js
@@ -1,8 +1,8 @@
-const BASE_URL = 'https://error-affirmations.herokuapp.com';
+import { API_BASE } from './api-config.js';
 
 /* Auth related functions */
 export async function getUser() {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/me`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/me`, {
         method: 'GET',
         headers: {
             Accept: 'application/json',
@@ -17,7 +17,7 @@ export async function getUser() {
 }
 
 export async function signUpUser(email, password) {
-    const resp = await fetch(`${BASE_URL}/api/v1/users`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',
@@ -36,7 +36,7 @@ export async function signUpUser(email, password) {
     return data;
 }
 export async function signInUser(email, password) {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/sessions`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',
@@ -54,7 +54,7 @@ export async function signInUser(email, password) {
     return data;
 }
 export async function signOutUser() {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/sessions`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
         method: 'DELETE',
         credentials: 'include',
     });
@@ -65,7 +65,7 @@ export async function signOutUser() {
 
 /* Data functions */
 export async function fetchAffirmations() {
-    const res = await fetch(`${BASE_URL}/api/v1/affirmations`, {
+    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
         method: 'GET',
         headers: {
             Accept: 'application/json',
@@ -83,7 +83,7 @@ export async function fetchAffirmations() {
 }
 
 export async function createAffirmation(text, category_id) {
-    const res = await fetch(`${BASE_URL}/api/v1/affirmations`, {
+    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',

--- a/fetch-utils.js
+++ b/fetch-utils.js
@@ -1,102 +1,144 @@
 import { API_BASE } from './api-config.js';
 
+const JSON_HEADERS = {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+};
+
+/**
+ * @typedef {{ ok: true, data: * }} FetchOk
+ * @typedef {{ ok: false, message: string, status?: number }} FetchErr
+ * UI-safe result for affirmation helpers: success carries payload in `data`, failure in `message`.
+ */
+
+/**
+ * Read response: verify res.ok, parse JSON when present, tolerate non-JSON error bodies.
+ * @param {Response} res
+ * @returns {Promise<FetchOk|FetchErr>}
+ */
+async function readResponse(res) {
+    const text = await res.text();
+    let body = null;
+    if (text) {
+        try {
+            body = JSON.parse(text);
+        } catch (parseErr) {
+            body = { message: text };
+        }
+    }
+    if (!res.ok) {
+        const message =
+            (body &&
+                (body.message ||
+                    (typeof body.error === 'string'
+                        ? body.error
+                        : body.error && body.error.message))) ||
+            res.statusText ||
+            'Request failed';
+        return { ok: false, message, status: res.status, data: body };
+    }
+    return { ok: true, data: body };
+}
+
 /* Auth related functions */
 export async function getUser() {
-    const resp = await fetch(`${API_BASE}/api/v1/users/me`, {
-        method: 'GET',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-    });
-    if (resp.ok) {
-        const user = await resp.json();
-        return user;
+    try {
+        const resp = await fetch(`${API_BASE}/api/v1/users/me`, {
+            method: 'GET',
+            headers: {
+                Accept: 'application/json',
+                'Content-Type': 'application/json',
+            },
+            credentials: 'include',
+        });
+        const result = await readResponse(resp);
+        if (!result.ok) {
+            return undefined;
+        }
+        return result.data;
+    } catch (e) {
+        return undefined;
     }
 }
 
 export async function signUpUser(email, password) {
-    const resp = await fetch(`${API_BASE}/api/v1/users`, {
-        method: 'POST',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password }),
-        credentials: 'include',
-    });
+    try {
+        const resp = await fetch(`${API_BASE}/api/v1/users`, {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ email, password }),
+            credentials: 'include',
+        });
+        const result = await readResponse(resp);
+        if (!result.ok) {
+            return { error: { message: result.message } };
+        }
+        return result.data;
+    } catch (e) {
+        return { error: { message: (e && e.message) || 'Network error' } };
+    }
+}
 
-    const data = await resp.json();
-    if (!resp.ok) {
-        // eslint-disable-next-line no-console
-        console.error(data.message);
-        data.error = data.message;
-    }
-    return data;
-}
 export async function signInUser(email, password) {
-    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
-        method: 'POST',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ email, password }),
-        credentials: 'include',
-    });
-    const data = await resp.json();
-    if (!resp.ok) {
-        // eslint-disable-next-line no-console
-        console.error(data.message);
-        data.error = data.message;
+    try {
+        const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ email, password }),
+            credentials: 'include',
+        });
+        const result = await readResponse(resp);
+        if (!result.ok) {
+            return { error: { message: result.message } };
+        }
+        return result.data;
+    } catch (e) {
+        return { error: { message: (e && e.message) || 'Network error' } };
     }
-    return data;
 }
+
 export async function signOutUser() {
-    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
-        method: 'DELETE',
-        credentials: 'include',
-    });
-    if (resp.ok) {
-        location.replace('/auth');
+    try {
+        const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
+            method: 'DELETE',
+            credentials: 'include',
+        });
+        if (resp.ok) {
+            location.replace('/auth');
+        }
+    } catch (e) {
+        // optional: could surface; sign-out is best-effort
     }
 }
 
 /* Data functions */
 export async function fetchAffirmations() {
-    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
-        method: 'GET',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-        },
-        credentials: 'include',
-    });
-    const data = await res.json();
-    if (res.ok) {
-        return data;
-    } else {
-        // eslint-disable-next-line no-console
-        console.error(data.message);
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
+            method: 'GET',
+            headers: JSON_HEADERS,
+            credentials: 'include',
+        });
+        return await readResponse(res);
+    } catch (e) {
+        return { ok: false, message: (e && e.message) || 'Network error' };
     }
 }
 
+/**
+ * POST /api/v1/affirmations — body matches backend: { text: string, category_id: string }.
+ * category_id is the string id from GET /api/v1/categories (e.g. "1" for daily).
+ */
 export async function createAffirmation(text, category_id) {
-    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
-        method: 'POST',
-        headers: {
-            Accept: 'application/json',
-            'Content-Type': 'application/json',
-        },
-        body: JSON.stringify({ text, category_id }),
-        credentials: 'include',
-    });
-    const data = await res.json();
-    if (res.ok) {
-        return data;
-    } else {
-        // eslint-disable-next-line no-console
-        console.error(data.message);
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
+            method: 'POST',
+            headers: JSON_HEADERS,
+            body: JSON.stringify({ text, category_id }),
+            credentials: 'include',
+        });
+        return await readResponse(res);
+    } catch (e) {
+        return { ok: false, message: (e && e.message) || 'Network error' };
     }
 }

--- a/index.html
+++ b/index.html
@@ -62,11 +62,11 @@
                 >
                 </textarea>
                 <label class="label">Category</label>
-                <select id="category-type" name="'category">
-                    <option>Daily</option>
-                    <option>Error</option>
-                    <option>TDD</option>
-                    <option>Will to go on</option>
+                <select id="category-type" name="category">
+                    <option value="1">Daily</option>
+                    <option value="2">Error</option>
+                    <option value="3">TDD</option>
+                    <option value="4">Will to go on</option>
                 </select>
                 <button id="submit-button">Submit</button>
             </form>


### PR DESCRIPTION
## Summary
Aligns the add-affirmation form with the API contract (`text` + `category_id` from `/api/v1/categories`) and hardens all fetch helpers for predictable client behavior.

## Security / UX
- **Safer response handling:** Checks `res.ok` before treating bodies as success; parses JSON in try/catch so HTML or plain-text error pages cannot crash the app.
- **No optimistic bad state:** Failed creates no longer `unshift` undefined or error payloads into the list.
- **User-visible errors:** Load and submit failures show a message in `#error-display` instead of failing silently.
- **Submit control:** The submit button is re-enabled in `finally` so users are not stuck after network or server errors.

## Test / lint
- `npx --yes eslint@8 .` passes.
- QUnit: `npx qunit test/index.js` requires `jsdom` (module missing in this environment); not run here.

## Files
- `index.html` — `name="category"`, option `value`s `1`–`4`
- `fetch-utils.js` — shared response parsing, consistent results
- `app.js` — error display, category labels, submit `finally`

Made with [Cursor](https://cursor.com)