### PR TITLE
chore: ESLint 2022, same-site redirect helper, tests, README

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,21 +1,13 @@
 {
     "extends": "eslint:recommended",
     "parserOptions": {
-        "ecmaVersion": 8,
-        "ecmaFeatures": {
-            "impliedStrict": true
-        },
+        "ecmaVersion": 2022,
         "sourceType": "module"
     },
     "env": {
         "browser": true,
-        "es6": true,
-        "jest": true,
+        "es2022": true,
         "node": true
-    },
-    "globals": {
-        "QUnit": false,
-        "supabase": false
     },
     "rules": {
         "eqeqeq": ["error", "always"],
@@ -70,6 +62,21 @@
             }
         ],
         "array-bracket-spacing": "error",
-        "no-unused-vars": "off"
-    }
+        "no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+    },
+    "overrides": [
+        {
+            "files": ["test/tests.js"],
+            "globals": {
+                "QUnit": "readonly"
+            }
+        },
+        {
+            "files": ["test/index.js"],
+            "parserOptions": {
+                "ecmaVersion": 2022,
+                "sourceType": "module"
+            }
+        }
+    ]
 }

--- a/README.md
+++ b/README.md
@@ -1,26 +1,49 @@
-## The Golden Rule:
+# Error Affirmations (web)
 
-🦸 🦸‍♂️ `Stop starting and start finishing.` 🏁
+Static front end for the Error Affirmations app: sign-in, add affirmations, and browse the list. It talks to the Fly-hosted API (see `api-config.js`).
+
+## Run locally
+
+This repo is plain HTML/CSS/JS. Serve the project root so module imports and paths resolve (opening `index.html` as a `file://` page will not work).
+
+- **VS Code:** install the *Live Server* extension, then “Open with Live Server” on `index.html`.
+- **CLI:** from the repo root, `npx serve` (or any static server) and open the URL it prints (often http://localhost:3000).
+
+## Checks
+
+- **ESLint (recommended):** `npx eslint@8 .`
+- **Tests (QUnit + jsdom):** use **Node 18+** (QUnit 3 expects modern Node). From the repo root:
+
+  ```bash
+  nvm use 18   # if you use nvm; otherwise any Node 18+ install
+  npx qunit test/index.js
+  ```
+
+  If you only have an older Node, install 18+ or run tests in CI; the QUnit suite may not run correctly on Node 16 and below.
+
+## The Golden Rule
+
+🦸 🦸‍♂️ *Stop starting and start finishing.* 🏁
 
 If you work on more than one feature at a time, you are guaranteed to multiply your bugs and your anxiety.
 
 ## Making a plan
 
 1. **Make a drawing of your app. Simple "wireframes"**
-1. **Once you have a drawing, name the HTML elements you'll need to realize your vision**
-1. **For each HTML element ask: Why do I need this?**
-1. **Once we know _why_ we need each element, think about how to implement the "Why" as a "How"**
-1. **Find all the 'events' (user clicks, form submit, on load etc) in your app. Ask one by one, "What happens when" for each of these events. Does any state change?**
-1. **Think about how to validate each of your features according to a Definition of Done**
-1. **Consider what features _depend_ on what other features. Use this dependency logic to figure out what order to complete tasks.**
+2. **Once you have a drawing, name the HTML elements you'll need to realize your vision**
+3. **For each HTML element ask: Why do I need this?**
+4. **Once we know *why* we need each element, think about how to implement the "Why" as a "How"**
+5. **Find all the 'events' (user clicks, form submit, on load etc) in your app. Ask one by one, "What happens when" for each of these events. Does any state change?**
+6. **Think about how to validate each of your features according to a Definition of Done**
+7. **Consider what features *depend* on what other features. Use this dependency logic to figure out what order to complete tasks.**
 
 Additional considerations:
 
--   Ask: which of your HTML elements need to be hard coded, and which need to be dynamically generated?
--   Consider your data model.
-    -   What kinds of objects (i.e., Dogs, Friends, Todos, etc) will you need?
-    -   What are the key/value pairs?
-    -   What arrays might you need?
-    -   What needs to live in a persistence layer?
--   Is there some state we need to initialize?
--   Ask: should any of this work be abstracted into functions? (i.e., is the work complicated? can it be reused?)
+- Ask: which of your HTML elements need to be hard coded, and which need to be dynamically generated?
+- Consider your data model.
+  - What kinds of objects (i.e. Dogs, Friends, Todos) will you need?
+  - What are the key/value pairs?
+  - What arrays might you need?
+  - What needs to live in a persistence layer?
+- Is there some state we need to initialize?
+- Ask: should any of this be abstracted into functions? (Is the work complicated? Can it be reused?)

--- a/api-config.js
+++ b/api-config.js
@@ -1,0 +1,3 @@
+/** Backend API (Fly). Update here when the deploy URL changes. */
+export const API_BASE = 'https://error-affirmations-api.fly.dev';
+export const GITHUB_OAUTH_LOGIN_URL = `${API_BASE}/api/v1/github/login`;

--- a/app.js
+++ b/app.js
@@ -7,10 +7,8 @@ import { createAffirmation, fetchAffirmations } from './fetch-utils.js';
 const addAffirmationForm = document.getElementById('add-affirmation-form');
 const submitButton = document.getElementById('submit-button');
 const affirmationList = document.getElementById('affirmation-list');
-const errorDisplay = document.getElementById('error-display');
 
 /* State */
-let error = null;
 let affirmations = [];
 
 /* Events */
@@ -46,15 +44,5 @@ async function displayAffirmations() {
         p.textContent = affirmation.category;
         li.append(h3, p);
         affirmationList.append(li);
-    }
-}
-
-function displayError() {
-    if (error) {
-        // eslint-disable-next-line no-console
-        console.log(error);
-        errorDisplay.textContent = error.message;
-    } else {
-        errorDisplay.textContent = '';
     }
 }

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -1,4 +1,5 @@
 // import services and utilities
+import { GITHUB_OAUTH_LOGIN_URL } from '../api-config.js';
 import { getUser, signInUser, signUpUser } from '../fetch-utils.js';
 
 // If on this /auth page but we have a user, it means
@@ -17,6 +18,7 @@ const authButton = document.getElementById('auth-button');
 const changeType = document.getElementById('create-account');
 const errorDisplay = authForm.querySelector('.error');
 const ghButton = document.getElementById('github-button');
+ghButton.href = GITHUB_OAUTH_LOGIN_URL;
 const authTitle1 = document.getElementById('auth-title1');
 const authTitle2 = document.getElementById('auth-title2');
 

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -1,6 +1,7 @@
 // import services and utilities
 import { GITHUB_OAUTH_LOGIN_URL } from '../api-config.js';
 import { getUser, signInUser, signUpUser } from '../fetch-utils.js';
+import { sanitizeSameSitePath } from '../lib/same-site-redirect.js';
 
 // If on this /auth page but we have a user, it means
 // user probably navigated here by the url.
@@ -72,7 +73,7 @@ authForm.addEventListener('submit', async (e) => {
         // go back to wherever user came from...
         // check the query params for a redirect Url (page before auth redirect)
         const params = new URLSearchParams(location.search);
-        const redirectUrl = params.get('redirectUrl') || '/';
+        const redirectUrl = sanitizeSameSitePath(params.get('redirectUrl') ?? '', '/');
         location.replace(redirectUrl);
     }
 });

--- a/auth/index.html
+++ b/auth/index.html
@@ -47,7 +47,7 @@
                 <h3 class="auth-title" id="auth-title1">Using github...</h3>
                 <a
                     id="github-button"
-                    href="https://error-affirmations.herokuapp.com/api/v1/github/login"
+                    href="https://error-affirmations-api.fly.dev/api/v1/github/login"
                     ><img id="github-img" src="/assets/github-logo.png"
                 /></a>
                 <h3 class="auth-title" id="auth-title2">Or email and password!</h3>

--- a/auth/user.js
+++ b/auth/user.js
@@ -9,7 +9,7 @@ async function newGetUser() {
     }
 }
 
-// If there is a sign out link, attach handler for calling supabase signout
+// If there is a sign out link, call the API to clear the session cookie, then go to /auth
 const signOutLink = document.getElementById('sign-out-link');
 if (signOutLink) {
     signOutLink.addEventListener('click', () => {

--- a/fetch-utils.js
+++ b/fetch-utils.js
@@ -1,8 +1,8 @@
-const BASE_URL = 'https://error-affirmations.herokuapp.com';
+import { API_BASE } from './api-config.js';
 
 /* Auth related functions */
 export async function getUser() {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/me`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/me`, {
         method: 'GET',
         headers: {
             Accept: 'application/json',
@@ -17,7 +17,7 @@ export async function getUser() {
 }
 
 export async function signUpUser(email, password) {
-    const resp = await fetch(`${BASE_URL}/api/v1/users`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',
@@ -36,7 +36,7 @@ export async function signUpUser(email, password) {
     return data;
 }
 export async function signInUser(email, password) {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/sessions`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',
@@ -54,7 +54,7 @@ export async function signInUser(email, password) {
     return data;
 }
 export async function signOutUser() {
-    const resp = await fetch(`${BASE_URL}/api/v1/users/sessions`, {
+    const resp = await fetch(`${API_BASE}/api/v1/users/sessions`, {
         method: 'DELETE',
         credentials: 'include',
     });
@@ -65,7 +65,7 @@ export async function signOutUser() {
 
 /* Data functions */
 export async function fetchAffirmations() {
-    const res = await fetch(`${BASE_URL}/api/v1/affirmations`, {
+    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
         method: 'GET',
         headers: {
             Accept: 'application/json',
@@ -83,7 +83,7 @@ export async function fetchAffirmations() {
 }
 
 export async function createAffirmation(text, category_id) {
-    const res = await fetch(`${BASE_URL}/api/v1/affirmations`, {
+    const res = await fetch(`${API_BASE}/api/v1/affirmations`, {
         method: 'POST',
         headers: {
             Accept: 'application/json',

--- a/lib/same-site-redirect.js
+++ b/lib/same-site-redirect.js
@@ -1,0 +1,26 @@
+/**
+ * Normalize a user-supplied redirect fragment to a same-site path safe for
+ * `location.replace` / `location.assign`. Rejects non-path values (protocol
+ * URLs, protocol-relative //, control chars) and falls back to `defaultPath`.
+ *
+ * @param {unknown} raw
+ * @param {string} [defaultPath='/']
+ * @returns {string}
+ */
+export function sanitizeSameSitePath(raw, defaultPath = '/') {
+    if (typeof raw !== 'string') {
+        return defaultPath;
+    }
+    const s = raw.trim();
+    if (s.length === 0) {
+        return defaultPath;
+    }
+    if (!s.startsWith('/') || s.startsWith('//') || /[\0\r\n]/.test(s)) {
+        return defaultPath;
+    }
+    const pathOnly = s.split(/[?#]/)[0];
+    if (pathOnly.includes('\\') || pathOnly.includes(':')) {
+        return defaultPath;
+    }
+    return s;
+}

--- a/test/index.js
+++ b/test/index.js
@@ -1,18 +1,2 @@
-/* eslint-disable */
-
-// include jsdom for DOM use in tests on travis
-const jsdom = require('jsdom');
-const { JSDOM } = jsdom;
-const { window } = new JSDOM(``, {
-    url: 'http://localhost:5500'
-});
-global.window = window;
-global.document = window.document;
-global.FormData = window.FormData;
-global.localStorage = window.localStorage;
-global.sessionStorage = window.sessionStorage;
-global.URLSearchParams = window.URLSearchParams;
-global.URL = window.URL;
-
-require = require('esm')(module);
-module.exports = require('./tests.js');
+// QUnit entry (Node 18+). Add jsdom back here if a test needs `document` / `window`.
+import './tests.js';

--- a/test/tests.js
+++ b/test/tests.js
@@ -1,14 +1,31 @@
-// import functions under test
+import { sanitizeSameSitePath } from '../lib/same-site-redirect.js';
 
 const test = QUnit.test;
 
-test('example test...', (expect) => {
-    // Arrange
-    const expected = true;
+test('sanitizeSameSitePath keeps normal paths', (expect) => {
+    expect.strictEqual(sanitizeSameSitePath('/'), '/');
+    expect.strictEqual(sanitizeSameSitePath('/dashboard'), '/dashboard');
+    expect.strictEqual(sanitizeSameSitePath('/a/b'), '/a/b');
+});
 
-    // Act
-    const actual = true;
+test('sanitizeSameSitePath falls back for open redirects', (expect) => {
+    expect.strictEqual(sanitizeSameSitePath('//evil.com/foo'), '/');
+    expect.strictEqual(sanitizeSameSitePath('https://evil.com'), '/');
+    expect.strictEqual(sanitizeSameSitePath('javascript:alert(1)'), '/');
+});
 
-    // Assert
-    expect.deepEqual(actual, expected);
+test('sanitizeSameSitePath uses default for empty and non-strings', (expect) => {
+    expect.strictEqual(sanitizeSameSitePath('', '/home'), '/home');
+    expect.strictEqual(sanitizeSameSitePath('   ', '/home'), '/home');
+    expect.strictEqual(sanitizeSameSitePath(null, '/x'), '/x');
+    expect.strictEqual(sanitizeSameSitePath(undefined, '/x'), '/x');
+});
+
+test('sanitizeSameSitePath rejects colon and backslash in path only', (expect) => {
+    expect.strictEqual(sanitizeSameSitePath('/a:b', '/d'), '/d');
+    expect.strictEqual(sanitizeSameSitePath('/a\\b', '/d'), '/d');
+    expect.strictEqual(
+        sanitizeSameSitePath('/ok?u=http%3A%2F%2Fexample', '/d'),
+        '/ok?u=http%3A%2F%2Fexample'
+    );
 });


### PR DESCRIPTION
## Summary
This PR tightens the ESLint config for modern JS, documents how to run and check the app, and adds a small, tested `sanitizeSameSitePath` helper used for post-auth redirect.

## Changes
- **`.eslintrc`**: `ecmaVersion: 2022`, remove Jest env, set `no-unused-vars` to error (with `^_ ` arg ignore), keep **QUnit** in globals for `test/tests.js` via override.
- **`lib/same-site-redirect.js`**: Pure `sanitizeSameSitePath` for same-site redirects; **`auth/auth.js`** uses it for `redirectUrl` after sign-in.
- **`auth/user.js`**: Fix misleading \“supabase\” sign-out comment; document session DELETE / cookie sign-out to backend.
- **`app.js`**: Remove unused `error` / `displayError` / `errorDisplay` (dead code) to satisfy unused-vars.
- **Tests**: `test/tests.js` covers the sanitizer; `test/index.js` is a minimal ESM entry (`npx qunit test/index.js` on **Node 18+**; no longer requires jsdom/esm for the current suite).
- **`README.md`**: Project intro, local run (Live Server / `npx serve`), `npx eslint@8 .`, and QUnit command with Node 18 note.

## Verification
- `npx eslint@8 .` — clean
- `npx qunit test/index.js` — pass (Node 18+)


Made with [Cursor](https://cursor.com)