### PR TITLE
fix(auth): session after signup; lint eqeqeq in app

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 /* Imports */
 import './auth/user.js';
 
-import { createAffirmation, fetchAffirmations } from './fetch-utils.js';
+import { createAffirmation, deleteAffirmation, fetchAffirmations, getUser } from './fetch-utils.js';
 
 /** Display labels for `category_id` from GET /api/v1/categories (values on `<select name="category">`). */
 const CATEGORY_LABELS = {
@@ -19,19 +19,21 @@ const errorDisplay = document.getElementById('error-display');
 
 /* State */
 let affirmations = [];
+let currentUser = null;
 let error = null;
 
 /* Events */
 window.addEventListener('load', async () => {
     affirmations = [];
-    const result = await fetchAffirmations();
-    if (!result.ok) {
-        error = { message: result.message };
+    const [userResult, affirmationsResult] = await Promise.all([getUser(), fetchAffirmations()]);
+    currentUser = userResult || null;
+    if (!affirmationsResult.ok) {
+        error = { message: affirmationsResult.message };
         displayError();
         return;
     }
     error = null;
-    affirmations = Array.isArray(result.data) ? result.data : [];
+    affirmations = Array.isArray(affirmationsResult.data) ? affirmationsResult.data : [];
     displayError();
     displayAffirmations();
 });
@@ -59,6 +61,12 @@ addAffirmationForm.addEventListener('submit', async (e) => {
     }
 });
 /* Display Functions */
+function isOwner(affirmation) {
+    if (!currentUser) return false;
+    if (currentUser.login) return affirmation.github_user_id == currentUser.id;
+    return affirmation.user_id == currentUser.id;
+}
+
 function displayAffirmations() {
     affirmationList.innerHTML = '';
     for (const affirmation of affirmations) {
@@ -75,8 +83,26 @@ function displayAffirmations() {
         categoryEl.textContent =
             CATEGORY_LABELS[id] || affirmation.category || id || '—';
         li.append(textEl, categoryEl);
+        if (isOwner(affirmation)) {
+            const deleteBtn = document.createElement('button');
+            deleteBtn.className = 'affirmation-item__delete';
+            deleteBtn.textContent = 'Delete';
+            deleteBtn.addEventListener('click', () => handleDelete(affirmation.id, li));
+            li.append(deleteBtn);
+        }
         affirmationList.append(li);
     }
+}
+
+async function handleDelete(id, li) {
+    const result = await deleteAffirmation(id);
+    if (!result.ok) {
+        error = { message: result.message };
+        displayError();
+        return;
+    }
+    affirmations = affirmations.filter((a) => a.id != id);
+    li.remove();
 }
 
 function displayError() {

--- a/app.js
+++ b/app.js
@@ -63,8 +63,9 @@ addAffirmationForm.addEventListener('submit', async (e) => {
 /* Display Functions */
 function isOwner(affirmation) {
     if (!currentUser) return false;
-    if (currentUser.login) return affirmation.github_user_id == currentUser.id;
-    return affirmation.user_id == currentUser.id;
+    if (currentUser.login)
+        return String(affirmation.github_user_id) === String(currentUser.id);
+    return String(affirmation.user_id) === String(currentUser.id);
 }
 
 function displayAffirmations() {
@@ -101,7 +102,7 @@ async function handleDelete(id, li) {
         displayError();
         return;
     }
-    affirmations = affirmations.filter((a) => a.id != id);
+    affirmations = affirmations.filter((a) => String(a.id) !== String(id));
     li.remove();
 }
 

--- a/auth/auth.js
+++ b/auth/auth.js
@@ -56,13 +56,19 @@ authForm.addEventListener('submit', async (e) => {
 
     // get the form data with email and password
     const formData = new FormData(authForm);
+    const email = formData.get('email');
+    const password = formData.get('password');
 
     let response = null;
 
     if (isSignIn) {
-        response = await signInUser(formData.get('email'), formData.get('password'));
+        response = await signInUser(email, password);
     } else {
-        response = await signUpUser(formData.get('email'), formData.get('password'));
+        response = await signUpUser(email, password);
+        // Registration does not set a session cookie; sign in immediately so / loads as authenticated.
+        if (!response.error) {
+            response = await signInUser(email, password);
+        }
     }
 
     const error = response.error;

--- a/fetch-utils.js
+++ b/fetch-utils.js
@@ -165,3 +165,16 @@ export async function createAffirmation(text, category_id) {
         return { ok: false, message: (e && e.message) || 'Network error' };
     }
 }
+
+export async function deleteAffirmation(id) {
+    try {
+        const res = await fetch(`${API_BASE}/api/v1/affirmations/${id}`, {
+            method: 'DELETE',
+            headers: JSON_HEADERS,
+            credentials: 'include',
+        });
+        return await readResponse(res);
+    } catch (e) {
+        return { ok: false, message: (e && e.message) || 'Network error' };
+    }
+}

--- a/styles/affirmations.css
+++ b/styles/affirmations.css
@@ -90,6 +90,27 @@ input[type='text'] {
     padding-top: 0.4rem;
 }
 
+.affirmation-item__delete {
+    align-self: flex-end;
+    margin-top: 0.4rem;
+    padding: 2px 10px;
+    font-size: 0.75rem;
+    cursor: pointer;
+    background-color: rgb(249, 159, 159);
+    border: 1px solid rgba(0, 0, 0, 0.4);
+    border-radius: 4px;
+    transition: 150ms;
+}
+
+.affirmation-item__delete:hover {
+    background-color: rgb(230, 80, 80);
+    color: white;
+}
+
+.affirmation-item__delete:active {
+    transform: scale(0.96);
+}
+
 #submit-button {
     margin-top: 5px;
     cursor: pointer;


### PR DESCRIPTION
## Summary
- **Auth:** After successful email sign-up, automatically call `signInUser` so the session cookie is set before redirect to `/` (avoids bounce back to `/auth/`).
- **Lint:** Replace `==` / `!=` on ids in `app.js` with `String()` comparisons for `eqeqeq` while keeping string/number id behavior.

## Verification
- `npm run lint` — pass
- `npm test` — pass
- API smoke: register → session → GET /me succeeds

## Included from `dev` (vs `main`)
This PR merges all commits currently on `dev` not on `main` (affirmation delete UX, sign-out refactor, signup name derivation, etc.).

Made with [Cursor](https://cursor.com)